### PR TITLE
Make compatible with IntelliJ IDEA 2020.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.madplay.madjenv'
-version '1.2a'
+version '1.3'
 
 sourceCompatibility = 11
 
@@ -18,7 +18,7 @@ dependencies {
 }
 
 intellij {
-    version '2020.2'
+    version '2020.3'
     plugins 'java'
     updateSinceUntilBuild false
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
 <idea-plugin>
     <id>MadJenvPlugin</id>
     <name>Mad-jEnv</name>
-    <version>1.2a</version>
+    <version>1.3</version>
     <vendor email="itsmetaeng@gmail.com" url="https://github.com/madplay/Mad-jEnv">madplay</vendor>
 
     <description><![CDATA[
@@ -86,11 +86,18 @@
         </ul>
         <br/>
 
+        <b>Changes in version 1.3:</b><br/>
+        <ul>
+          <li>#45: fix: Not compatible with IntelliJ IDEA 2020.3
+          </li>
+        </ul>
+        <br/>
+
         </html>
         ]]>
     </change-notes>
 
-    <idea-version since-build="193.0" until-build="202.*"/>
+    <idea-version since-build="193.0" until-build="203.*"/>
 
     <depends>com.intellij.modules.java</depends>
 


### PR DESCRIPTION
Fix https://github.com/madplay/Mad-jEnv/issues/49

- [x] It builds on my machine (`./gradlew build`)
- [x] I can install it in IntelliJ IDEA 2020.3 and it "works"